### PR TITLE
[mono-symbolicate] [WIP] Use IKVM.Reflection instead of System.Reflec…

### DIFF
--- a/mcs/class/corlib/System.Diagnostics/StackTraceHelper.cs
+++ b/mcs/class/corlib/System.Diagnostics/StackTraceHelper.cs
@@ -26,11 +26,16 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 
-using System.Text;
-using System.Reflection;
-
 namespace System.Diagnostics {
 
+	using System.Text;
+#if INSIDE_CORLIB
+	using System.Reflection;
+#else
+	using IKVM.Reflection;
+	using IKVM.Reflection.Reader;
+	using Type = IKVM.Reflection.Type;
+#endif
 	// This class exists so tools such as mono-symbolicate can use it directly.
 	class StackTraceHelper {
 		
@@ -76,11 +81,8 @@ namespace System.Diagnostics {
 				if (pt.IsGenericType && ! pt.IsGenericTypeDefinition)
 					pt = pt.GetGenericTypeDefinition ();
 
-				if (pt.IsClass && !String.IsNullOrEmpty (pt.Namespace)) {
-					sb.Append (pt.Namespace);
-					sb.Append (".");
-				}
-				sb.Append (pt.Name);
+				sb.Append (pt.ToString());
+
 				if (p [i].Name != null) {
 					sb.Append (" ");
 					sb.Append (p [i].Name);

--- a/mcs/tools/mono-symbolicate/LocationProvider.cs
+++ b/mcs/tools/mono-symbolicate/LocationProvider.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Reflection;
+using IKVM.Reflection;
 using System.Diagnostics;
 using System.Collections.Generic;
 using Mono.Cecil;
@@ -77,6 +77,7 @@ namespace Symbolicate
 			}
 		}
 
+		static readonly Universe ikvm_reflection = new Universe ();
 		Dictionary<string, AssemblyLocationProvider> assemblies;
 		HashSet<string> directories;
 
@@ -94,14 +95,14 @@ namespace Symbolicate
 			if (!File.Exists (assemblyPath))
 				throw new ArgumentException ("assemblyPath does not exist: "+ assemblyPath);
 
-			var assembly = Assembly.ReflectionOnlyLoadFrom (assemblyPath);
+			var assembly = ikvm_reflection.LoadFile (assemblyPath);
 			MonoSymbolFile symbolFile = null;
 
 			var symbolPath = assemblyPath + ".mdb";
 			if (!File.Exists (symbolPath))
 				Debug.WriteLine (".mdb file was not found for " + assemblyPath);
 			else
-				symbolFile = MonoSymbolFile.ReadSymbolFile (assemblyPath + ".mdb");
+				symbolFile = MonoSymbolFile.ReadSymbolFile (symbolPath);
 
 			var seqPointDataPath = assemblyPath + ".msym";
 			if (!File.Exists (seqPointDataPath))

--- a/mcs/tools/mono-symbolicate/Makefile
+++ b/mcs/tools/mono-symbolicate/Makefile
@@ -9,7 +9,8 @@ LOCAL_MCS_FLAGS = \
 	/r:Mono.CompilerServices.SymbolWriter.dll \
 	/r:System.Xml.dll \
 	/r:System.Core.dll \
-	/r:System.dll
+	/r:System.dll \
+	/D:NO_AUTHENTICODE
 
 include ../../build/executable.make
 

--- a/mcs/tools/mono-symbolicate/Test/symbolicate.expected
+++ b/mcs/tools/mono-symbolicate/Test/symbolicate.expected
@@ -11,22 +11,22 @@ Stacktrace:
   at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 
 System.Exception: Stacktrace with 3 frames
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
   at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
   at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
   at StackTraceDumper.<Main>m__1 () in StackTraceDumper.cs:18 
   at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 
 System.Exception: Stacktrace with 4 frames
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:76 
   at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
   at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 Stacktrace:
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:78 
-  at StackTraceDumper.ThrowException (System.String message, Int32 i) in StackTraceDumper.cs:76 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:78 
+  at StackTraceDumper.ThrowException (System.String message, System.Int32 i) in StackTraceDumper.cs:76 
   at StackTraceDumper.<Main>m__2 () in StackTraceDumper.cs:20 
   at StackTraceDumper.Catch (System.Action action) in StackTraceDumper.cs:54 
 

--- a/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
+++ b/mcs/tools/mono-symbolicate/mono-symbolicate.exe.sources
@@ -2,3 +2,9 @@ symbolicate.cs
 LocationProvider.cs
 SeqPointInfo.cs
 ../../class/corlib/System.Diagnostics/StackTraceHelper.cs
+../../../external/ikvm/reflect/*.cs
+../../../external/ikvm/reflect/Impl/*.cs
+../../../external/ikvm/reflect/Emit/*.cs
+../../../external/ikvm/reflect/Metadata/*.cs
+../../../external/ikvm/reflect/Reader/*.cs
+../../../external/ikvm/reflect/Writer/*.cs


### PR DESCRIPTION
…tion

This is so that the tool can work independently of runtime assembly resolution (ie. to load alternate corlibs)
